### PR TITLE
Updated README.md with OS X Homebrew instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ On Debian Wheezy you run the same command, but you must first add backports to y
 
     sudo port install ruby coreutils
     export PATH=$PATH:/opt/local/libexec/gnubin  # Needed for sha256sum
+    
+### OSX with Homebrew:
+
+    brew install ruby coreutils
+    export PATH=$PATH:/opt/local/libexec/gnubin    
 
 #### VirtualBox:
 


### PR DESCRIPTION
Added info for OS X homebrew commands alongside the Macports as some people prefer to use Homebrew over MacPorts and it is a pain to switch over from the two.
